### PR TITLE
Implement dependencies versions ranges in Cargo.toml and badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # redsumer-rs
 
+<div align="left">
+	<img src="https://img.shields.io/github/license/enerBit/redsumer-rs">
+	<a href="https://deps.rs/repo/github/enerBit/redsumer-rs">
+		<img src="https://deps.rs/repo/github/enerBit/redsumer-rs/status.svg">
+	</a>
+	<a href="https://github.com/enerBit/redsumer-rs/actions/workflows/CI.yml">
+		<img src="https://github.com/enerBit/redsumer-rs/actions/workflows/CI.yml/badge.svg">
+	</a>
+	<a href="https://crates.io/crates/redsumer">
+		<img src="https://img.shields.io/crates/v/redsumer.svg?label=crates.io&color=orange&logo=rust">
+	</a>
+	<a href="http://docs.rs/redsumer/latest/">
+		<img src="https://img.shields.io/static/v1?label=docs.rs&message=latest&color=blue&logo=docsdotrs">
+	</a>
+</div>
+
 A lightweight implementation of Redis Streams for Rust, allowing you to manage streaming messages in a simplified way. With redsumer you can:
 
 - **Produce** new messages in a specific *stream*.

--- a/redsumer-rs/Cargo.toml
+++ b/redsumer-rs/Cargo.toml
@@ -20,8 +20,8 @@ authors = [
 ]
 
 [dependencies]
-redis = { version = "0.27.2", features = ["tokio-comp", "streams"] }
-tracing = { version = "0.1.40" }
+redis = { version = ">=0.27.2", features = ["tokio-comp", "streams"] }
+tracing = { version = ">=0.1.40" }
 
 [dev-dependencies]
 redis-test = { version = "0.6.0" }


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to add various badges and modifies the dependency versions in the `Cargo.toml` file. 

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R18): Added badges for license, dependency status, CI status, crates.io version, and documentation.

Dependency updates:

* [`redsumer-rs/Cargo.toml`](diffhunk://#diff-8263ffd4fca01ca77c83a85e9a0e49d3cc4f58aee24d2118d93f02e2fd1d456aL23-R24): Updated `redis` and `tracing` dependencies to use version ranges instead of fixed versions.