### PR TITLE
Update version in Cargo.toml from v0.5.0-beta.1 to v0.5.0

### DIFF
--- a/redsumer-rs/Cargo.toml
+++ b/redsumer-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redsumer"
 description = "Lightweight implementation of Redis Streams for Rust"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 edition = "2021"
 license-file = "../LICENSE"
 readme = "../README.md"


### PR DESCRIPTION
This pull request includes a version update for the `redsumer` package in the `Cargo.toml` file. The version has been changed from `0.5.0-beta.1` to `0.5.0`.

* [`redsumer-rs/Cargo.toml`](diffhunk://#diff-8263ffd4fca01ca77c83a85e9a0e49d3cc4f58aee24d2118d93f02e2fd1d456aL4-R4): Updated the package version from `0.5.0-beta.1` to `0.5.0`.