### PR TITLE
Implement function belongs_to_me

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ async fn main() {
                 panic!(
                     "Error checking if message is still in consumer pending list: {:?}", error
                 );
-            }).is_still_mine() {
+            }).belongs_to_me() {
                 // Process message ...
                 println!("Processing message: {:?}", message);
                 // ...

--- a/redsumer-rs/CHANGELOG.md
+++ b/redsumer-rs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added:
+
+- ⚡ Implement `belongs_to_me()` in `IsStillMineReply` to verify if the message is still in consumer pending list. Function `is_still_mine()` was deprecated. By [@JMTamayo](https://github.com/JMTamayo).
+
 ## ✨ v0.5.0 [2024-10-26]
 
 ### Added:

--- a/redsumer-rs/src/lib.rs
+++ b/redsumer-rs/src/lib.rs
@@ -154,7 +154,7 @@
 //!                 panic!(
 //!                     "Error checking if message is still in consumer pending list: {:?}", error
 //!                 );
-//!             }).is_still_mine() {
+//!             }).belongs_to_me() {
 //!                 // Process message ...
 //!                 println!("Processing message: {:?}", message);
 //!                 // ...

--- a/redsumer-rs/src/redsumer/consumer.rs
+++ b/redsumer-rs/src/redsumer/consumer.rs
@@ -312,7 +312,13 @@ pub struct IsStillMineReply {
 
 impl IsStillMineReply {
     /// Get **is still mine**.
+    #[deprecated(note = "Please use the `belongs_to_me` function instead")]
     pub fn is_still_mine(&self) -> bool {
+        self.belongs_to_me()
+    }
+
+    /// Verify if the message still belongs to the consumer.
+    pub fn belongs_to_me(&self) -> bool {
         self.is_still_mine
     }
 
@@ -793,7 +799,7 @@ mod test_is_still_mine_reply {
         ));
 
         // Verify the result:
-        assert!(reply.is_still_mine());
+        assert!(reply.belongs_to_me());
 
         assert!(reply.get_last_delivered_milliseconds().is_some());
         assert!(reply


### PR DESCRIPTION
This pull request includes some changes to the `redsumer-rs` project, focusing on deprecating the `is_still_mine` function and replacing it with the new `belongs_to_me` function. The changes span multiple files, including updates to documentation and tests.

Deprecation and new function:

* [`redsumer-rs/src/redsumer/consumer.rs`](diffhunk://#diff-d8ea66f5192baf26ca8fce4ed12ab406d4df8351201b45291b4586f61faee303R315-R321): Deprecated the `is_still_mine` function in `IsStillMineReply` and introduced the new `belongs_to_me` function to verify if the message still belongs to the consumer.

Code updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L173-R173): Updated the function call from `is_still_mine` to `belongs_to_me` in the example code.
* [`redsumer-rs/src/lib.rs`](diffhunk://#diff-cdc64032cd76b926c84e50ef92114f5f830ddb6c904e7828cc3713de624e07eeL157-R157): Updated the function call from `is_still_mine` to `belongs_to_me` in the documentation comments.

Testing:

* [`redsumer-rs/src/redsumer/consumer.rs`](diffhunk://#diff-d8ea66f5192baf26ca8fce4ed12ab406d4df8351201b45291b4586f61faee303L796-R802): Modified the test in `mod test_is_still_mine_reply` to use `belongs_to_me` instead of `is_still_mine`.

Documentation:

* [`redsumer-rs/CHANGELOG.md`](diffhunk://#diff-3f431c7f65500755afd7e45ea1c9d792b156b1b9e1bec3b6668f8fdcc24b6f83R8-R13): Documented the addition of the `belongs_to_me` function and the deprecation of `is_still_mine` in the changelog.