### PR TITLE
Unify Unit Tests and Coverage steps in CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+		
       - name: "Setup: Install Rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
         with:
@@ -20,9 +23,6 @@ jobs:
         uses: taiki-e/install-action@v2.33.22
         with:
           tool: cargo-llvm-cov
-
-      - name: Checkout
-        uses: actions/checkout@v3
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,9 +34,6 @@ jobs:
         run: cargo clippy --package redsumer --all-features --verbose
 
       - name: Unit Tests
-        run: cargo test --package redsumer --verbose
-
-      - name: Coverage
         env:
           MIN_LINE_COVERAGE_TARGET: 80
         run: cargo llvm-cov --package redsumer --all-features --summary-only --fail-under-lines ${{ env.MIN_LINE_COVERAGE_TARGET }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-		
+
       - name: "Setup: Install Rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
         with:

--- a/redsumer-rs/CHANGELOG.md
+++ b/redsumer-rs/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ⚡ Implement `belongs_to_me()` in `IsStillMineReply` to verify if the message is still in consumer pending list. Function `is_still_mine()` was deprecated. By [@JMTamayo](https://github.com/JMTamayo).
 
+### Changed:
+
+- 🚀 Unify *Unit Tests* and *Coverage* steps in CI pipeline. By [@JMTamayo](https://github.com/JMTamayo).
+- 🚀 Making the *Checkout* step the first step in the pipeline to ensure that the code is available prior to the execution of the CI flow. By [@JMTamayo](https://github.com/JMTamayo).
+
 ## ✨ v0.5.0 [2024-10-26]
 
 ### Added:


### PR DESCRIPTION
This pull request includes changes to the CI pipeline configuration and updates to the changelog. The most important changes include unifying the Unit Tests and Coverage steps, and ensuring the Checkout step is the first in the pipeline.

Changes to CI pipeline:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L37-L39): Unified the Unit Tests and Coverage steps into a single step.
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R14-R16): Moved the Checkout step to be the first step in the pipeline. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R14-R16) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L24-L26)

Updates to changelog:

* [`redsumer-rs/CHANGELOG.md`](diffhunk://#diff-3f431c7f65500755afd7e45ea1c9d792b156b1b9e1bec3b6668f8fdcc24b6f83R14-R18): Added entries to reflect the unification of Unit Tests and Coverage steps, and the reordering of the Checkout step in the CI pipeline.