### PR TITLE
Update CI pipeline: Apply steps to workspace and include doc tests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,15 +25,18 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --workspace --all-features
 
       - name: Format
-        run: cargo fmt --package redsumer --all --check
+        run: cargo fmt --all --check
 
       - name: Lints
-        run: cargo clippy --package redsumer --all-features --verbose
+        run: cargo clippy --workspace --all-features
 
       - name: Unit Tests
         env:
           MIN_LINE_COVERAGE_TARGET: 80
-        run: cargo llvm-cov --package redsumer --all-features --summary-only --fail-under-lines ${{ env.MIN_LINE_COVERAGE_TARGET }}
+        run: cargo llvm-cov --workspace --all-features --show-missing-lines --summary-only --fail-under-lines ${{ env.MIN_LINE_COVERAGE_TARGET }}
+
+      - name: Doc Tests
+        run: cargo test --workspace --all-features --doc

--- a/Makefile
+++ b/Makefile
@@ -5,25 +5,22 @@ fmt-check:
 	cargo fmt --all --check
 
 check:
-	cargo check --all-features
+	cargo check --workspace --all-features
 
 clippy-check:
-	cargo clippy --all-features
+	cargo clippy --workspace --all-features
 
 install-llvm-cov:
 	cargo install cargo-llvm-cov
 
 test-llvm-cov-report:
-	cargo llvm-cov --html --workspace --all-features
+	cargo llvm-cov --workspace --all-features --show-missing-lines --open
 
 test-llvm-cov-target:
-	cargo llvm-cov --workspace --all-features --summary-only --fail-under-lines 70
+	cargo llvm-cov --workspace --all-features --show-missing-lines --summary-only --fail-under-lines 80
 
-test:
-	cargo test --all-features
+test-doc:
+	cargo test --workspace --all-features --doc
 
 doc:
-	cargo doc --all-features
-
-doc-open:
-	cargo doc --all-features --open
+	cargo doc --workspace --all-features --open


### PR DESCRIPTION
This pull request includes changes to the CI workflow and the Makefile to ensure consistency and improve the testing and documentation processes. The most important changes include updating commands to use the `--workspace` and `--all-features` flags, adding a new step for documentation tests, and modifying coverage reporting to show missing lines.

### CI Workflow Improvements:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L28-R42): Updated build, format, lints, and unit tests commands to use the `--workspace` and `--all-features` flags. Added a new step for documentation tests.

### Makefile Enhancements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L8-R26): Updated `check`, `clippy-check`, and `test-llvm-cov-report` commands to use the `--workspace` and `--all-features` flags. Added `--show-missing-lines` to coverage reporting and included a new `test-doc` target for documentation tests.