### PR TITLE
Implement schedule cronjob to run CI each Sunday at 05:00 UTC

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  schedule:
+    - cron: "0 5 * * 0"
 
 env:
   LOG_LEVEL: debug


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/CI.yml` file. The change adds a scheduled job to the CI workflow that runs every Sunday at 5 AM.

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R8-R9): Added a `schedule` trigger to run the CI workflow every Sunday at 5 AM.