### PR TITLE
Implement dependency in the execution of CI steps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,7 @@ jobs:
 
   Build:
     runs-on: ubuntu-latest
+    needs: Config-files
     steps:
       - name: Fetch Repository
         uses: actions/checkout@v4
@@ -66,6 +67,21 @@ jobs:
       - name: Build
         run: cargo build --workspace --all-features
 
+  Tests:
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v4
+
+      - name: Setup cargo-llvm-cov
+        uses: taiki-e/install-action@v2.33.22
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Unit & Integration Tests
+        run: cargo llvm-cov --workspace --all-features --show-missing-lines --summary-only --fail-under-lines ${{ env.MIN_LINE_COVERAGE_TARGET }}		
+
   Documentation:
     runs-on: ubuntu-latest
     steps:
@@ -80,20 +96,6 @@ jobs:
 
       - name: Doc Tests
         run: cargo test --workspace --all-features --doc
-
-  Tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch Repository
-        uses: actions/checkout@v4
-
-      - name: Setup cargo-llvm-cov
-        uses: taiki-e/install-action@v2.33.22
-        with:
-          tool: cargo-llvm-cov
-
-      - name: Unit & Integration Tests
-        run: cargo llvm-cov --workspace --all-features --show-missing-lines --summary-only --fail-under-lines ${{ env.MIN_LINE_COVERAGE_TARGET }}
 
   Security:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Unit & Integration Tests
-        run: cargo llvm-cov --workspace --all-features --show-missing-lines --summary-only --fail-under-lines ${{ env.MIN_LINE_COVERAGE_TARGET }}		
+        run: cargo llvm-cov --workspace --all-features --show-missing-lines --summary-only --fail-under-lines ${{ env.MIN_LINE_COVERAGE_TARGET }}
 
   Documentation:
     runs-on: ubuntu-latest

--- a/redsumer-rs/CHANGELOG.md
+++ b/redsumer-rs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ⚡ Implement `cargo-deny` in CI pipeline to verify security vulnerabilities. By [@JMTamayo](https://github.com/JMTamayo).
 - ⚡ Implement `cargo verify-project`, `yamlfmt` and `taplo` in CI pipeline to verify config files format. By [@JMTamayo](https://github.com/JMTamayo).
 - ⚡ Implement `cargo-audit`, `cargo-deny`, `cargo verify-project`, `yamlfmt`and `taplo` in Makefile. By [@JMTamayo](https://github.com/JMTamayo).
+- ⚡ Implement scheduled job to run CI pipeline each Sunday at 05:00 UTC. By [@JMTamayo](https://github.com/JMTamayo).
 
 ### Changed:
 


### PR DESCRIPTION
This pull request includes changes to the CI pipeline configuration and the project changelog. The most important changes include restructuring the CI workflow to add dependencies between jobs and adding a scheduled job to run the CI pipeline weekly.

CI pipeline improvements:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R51): Added `needs: Config-files` dependency to the `Build` job to ensure it runs after the configuration files are set up.
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R70-R84): Reintroduced the `Tests` job with dependencies on the `Build` job and added steps for fetching the repository, setting up `cargo-llvm-cov`, and running unit and integration tests.
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L84-L97): Removed the previously defined `Tests` job that did not have dependencies and steps for setting up and running tests.

Documentation update:

* [`redsumer-rs/CHANGELOG.md`](diffhunk://#diff-3f431c7f65500755afd7e45ea1c9d792b156b1b9e1bec3b6668f8fdcc24b6f83R15): Added an entry for the implementation of a scheduled job to run the CI pipeline every Sunday at 05:00 UTC.