### PR TITLE
Documentation improvements for first version of resumer-core

### DIFF
--- a/redsumer-core/CHANGELOG.md
+++ b/redsumer-core/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog 📘💜
+
+All notable changes to `redsumer-core` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## ✨ v0.1.0 [*Pending*]
+
+### Added:
+
+- ⚡ Implement the first version of the crate based on the [redsumer core](https://github.com/enerBit/redsumer-rs/tree/v0.5.2/redsumer-rs/src/core) module of version v0.5.2. By [@JMTamayo](https://github.com/JMTamayo).

--- a/redsumer-core/Cargo.toml
+++ b/redsumer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redsumer-core"
-description = "Lightweight implementation of Redis Streams for Rust"
+description = "Core functionalities for redsumer written in Rust"
 version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"

--- a/redsumer-core/README.md
+++ b/redsumer-core/README.md
@@ -1,0 +1,17 @@
+# Redsumer Core
+
+This package contains the core functionality of `Redsumer`, whose process focuses on consuming messages from a stream, reducing the probability that two or more consumers from the same group process the same message successfully, incurring major errors in the implementation.
+
+## License
+
+Licensed under [MIT](../LICENSE).
+
+## Contributing
+
+We welcome contributions to **redsumer-core**. Here are some ways you can contribute:
+
+- **Bug Reports**: If you find a bug, please create an issue detailing the problem, the steps to reproduce it, and the expected behavior.
+- **Feature Requests**: If you have an idea for a new feature or an enhancement to an existing one, please create an issue describing your idea.
+- **Pull Requests**: If you've fixed a bug or implemented a new feature, we'd love to see your work! Please submit a pull request. Make sure your code follows the existing style and all tests pass.
+
+Thank you for your interest in improving **redsumer-core**!

--- a/redsumer-core/src/redsumer_core/client.rs
+++ b/redsumer-core/src/redsumer_core/client.rs
@@ -5,18 +5,18 @@ use redis::{Client, ConnectionAddr, ConnectionInfo, ProtocolVersion, RedisConnec
 #[allow(unused_imports)]
 use super::result::{RedsumerError, RedsumerResult};
 
-/// Communication protocol to be used by the client. It is an alias for [`ProtocolVersion`].
+/// Communication protocol to be used by the client.
 pub type CommunicationProtocol = ProtocolVersion;
 
-/// To hold credentials to authenticate in Redis.
+/// To hold credentials to authenticate to the server.
 ///
-/// This credentials are used to authenticate in Redis when server requires it. If server does not require it, you set it to `None`.
+/// This credentials are used to authenticate to the server when required. If server does not require it, you set it to `None`.
 #[derive(Clone)]
 pub struct ClientCredentials {
-    /// User to authenticate in Redis service.
+    /// User to authenticate to the server.
     user: String,
 
-    /// Password to authenticate in Redis service.
+    /// Password to authenticate to the server.
     password: String,
 }
 
@@ -34,8 +34,8 @@ impl ClientCredentials {
     /// Build a new instance of [`ClientCredentials`].
     ///
     /// # Arguments:
-    /// - **user**: The username to authenticate in Redis service.
-    /// - **password**: The password to authenticate in Redis service.
+    /// - **user**: The username to authenticate to the server.
+    /// - **password**: The password to authenticate to the server.
     ///
     /// # Returns:
     /// A new instance of [`ClientCredentials`].
@@ -62,22 +62,22 @@ impl Debug for ClientCredentials {
 ///
 /// `redis://[<user>][:<password>@]<host>:<port>/<db>`
 ///
-/// *user* and *password* are optional. If you don't need to authenticate in Redis, you can ignore them. *port* and *db* are mandatory for the connection. Another connection URL formats are not implemented yet.
+/// *user* and *password* are optional. If you don't need to authenticate to the server, you can ignore them. *port* and *db* are mandatory for the connection. Another connection URL formats are not implemented yet.
 #[derive(Debug, Clone)]
 pub struct ClientArgs {
-    /// Credentials to authenticate in Redis.
+    /// Credentials to authenticate to the server.
     credentials: Option<ClientCredentials>,
 
-    /// Host to connect to Redis.
+    /// Host to connect to the server.
     host: String,
 
-    /// Redis server port.
+    /// Server port.
     port: u16,
 
-    /// Redis database number.
+    /// Database number.
     db: i64,
 
-    /// Redis protocol version to communicate with the server.
+    /// Protocol version to communicate with the server.
     protocol: CommunicationProtocol,
 }
 
@@ -110,11 +110,11 @@ impl ClientArgs {
     /// Create a new instance of [`ClientArgs`].
     ///
     /// # Arguments:
-    /// - **credentials**: Credentials to authenticate in Redis.
-    /// - **host**: Host to connect to Redis.
-    /// - **port**: Redis server port.
-    /// - **db**: Redis database
-    /// - **protocol**: Redis protocol version to communicate with the server.
+    /// - **credentials**: Credentials to authenticate to the server.
+    /// - **host**: Host to connect to the server.
+    /// - **port**: Server port.
+    /// - **db**: Database number.
+    /// - **protocol**: Protocol version to communicate with the server.
     ///
     /// # Returns:
     /// A new instance of [`ClientArgs`].
@@ -136,7 +136,7 @@ impl ClientArgs {
 }
 
 /// To build a new instance of [`Client`].
-pub trait RedisClientBuilder {
+pub trait ClientBuilder {
     /// Build a new instance of [`Client`].
     ///
     /// # Arguments:
@@ -147,7 +147,7 @@ pub trait RedisClientBuilder {
     fn build(&self) -> RedsumerResult<Client>;
 }
 
-impl RedisClientBuilder for ClientArgs {
+impl ClientBuilder for ClientArgs {
     fn build(&self) -> RedsumerResult<Client> {
         let addr: ConnectionAddr =
             ConnectionAddr::Tcp(String::from(self.get_host()), self.get_port());

--- a/redsumer-core/src/redsumer_core/connection.rs
+++ b/redsumer-core/src/redsumer_core/connection.rs
@@ -4,26 +4,29 @@ use tracing::{debug, error};
 #[allow(unused_imports)]
 use crate::redsumer_core::result::{RedsumerError, RedsumerResult};
 
+/// Verify the connection to the server.
+/// 
+/// This method sends a `PING` command to the server to verify the connection and returns `PONG` if the connection was verified successfully.
 fn ping<C>(c: &mut C) -> RedisResult<String>
 where
     C: Commands,
 {
     match c.check_connection() {
         true => {
-            debug!("The connection to the Redis server was verified");
+            debug!("The connection to the server was verified");
             Ok("PONG".into())
         }
         false => {
-            let e: &str = "The connection to the Redis server could not be verified. Please verify the client configuration or server availability";
+            let e: &str = "The connection to the server could not be verified. Please verify the client configuration or server availability";
             error!(e);
             Err(RedisError::from((ErrorKind::ClientError, e)))
         }
     }
 }
 
-/// A trait to verify the connection to the Redis server.
+/// A trait to verify the connection to the server.
 pub trait VerifyConnection {
-    /// Verify the connection to the Redis server.
+    /// Verify the connection to the server.
     ///
     /// # Arguments:
     /// - No arguments.
@@ -72,6 +75,6 @@ mod test_connection {
 
         // Verify the connection to the server:
         assert!(ping_result.is_err());
-        assert_eq!(ping_result.unwrap_err().to_string(), "The connection to the Redis server could not be verified. Please verify the client configuration or server availability- ClientError");
+        assert_eq!(ping_result.unwrap_err().to_string(), "The connection to the server could not be verified. Please verify the client configuration or server availability- ClientError");
     }
 }

--- a/redsumer-core/src/redsumer_core/connection.rs
+++ b/redsumer-core/src/redsumer_core/connection.rs
@@ -5,7 +5,7 @@ use tracing::{debug, error};
 use crate::redsumer_core::result::{RedsumerError, RedsumerResult};
 
 /// Verify the connection to the server.
-/// 
+///
 /// This method sends a `PING` command to the server to verify the connection and returns `PONG` if the connection was verified successfully.
 fn ping<C>(c: &mut C) -> RedisResult<String>
 where

--- a/redsumer-core/src/redsumer_core/result.rs
+++ b/redsumer-core/src/redsumer_core/result.rs
@@ -1,6 +1,6 @@
 use redis::RedisError;
 
-/// Error type for *redsumer* operations, it is an alias for [`RedisError`].
+/// Error type for *redsumer* operations.
 pub type RedsumerError = RedisError;
 
 /// Result type for *redsumer* operations.

--- a/redsumer-core/src/redsumer_core/streams/consumer.rs
+++ b/redsumer-core/src/redsumer_core/streams/consumer.rs
@@ -82,7 +82,7 @@ where
 }
 
 /// Create a consumer group in a stream.
-/// 
+///
 /// if the consumer group already exists, the function will return a success result with a `false` value. If the consumer group does not exist, the function will create it and return a success result with a `true` value.
 fn create_consumer_group<C, K, G, ID>(
     conn: &mut C,

--- a/redsumer-core/src/redsumer_core/streams/consumer.rs
+++ b/redsumer-core/src/redsumer_core/streams/consumer.rs
@@ -53,7 +53,7 @@ where
     }
 }
 
-/// Verify if a stream exists in Redis Stream service.
+/// Verify if a stream exists.
 fn verify_if_stream_exists<C, K>(conn: &mut C, key: K) -> RedsumerResult<()>
 where
     C: Commands,
@@ -82,6 +82,8 @@ where
 }
 
 /// Create a consumer group in a stream.
+/// 
+/// if the consumer group already exists, the function will return a success result with a `false` value. If the consumer group does not exist, the function will create it and return a success result with a `true` value.
 fn create_consumer_group<C, K, G, ID>(
     conn: &mut C,
     key: K,
@@ -283,15 +285,15 @@ where
     }
 }
 
-/// A trait that bundles methods for consuming messages from a Redis stream
+/// A trait that bundles methods for consuming messages from a stream.
 pub trait ConsumerCommands<K>
 where
     K: ToRedisArgs,
 {
-    /// Verify if a stream exists in Redis Stream service.
+    /// Verify if a stream exists.
     ///
     /// # Arguments:
-    /// - **key**: A stream key, which must implement the `ToRedisArgs` trait.
+    /// - **key**: A stream key.
     ///
     /// # Returns:
     /// A [`RedsumerResult`] with the result of the operation.
@@ -300,12 +302,12 @@ where
     /// If an error occurs, the function will return an error result.
     fn verify_if_stream_exists(&mut self, key: K) -> RedsumerResult<()>;
 
-    /// Create a consumer group in a Redis stream.
+    /// Create a consumer group in a stream..
     ///
     /// # Arguments:
-    /// - **key**: A stream key, which must implement the `ToRedisArgs` trait.
-    /// - **group**: A consumers group, which must implement the `ToRedisArgs` trait.
-    /// - **since_id**: The ID of the message to start consuming, which must implement the `ToRedisArgs` trait.
+    /// - **key**: A stream key.
+    /// - **group**: A consumers group.
+    /// - **since_id**: The message ID to start consuming.
     ///
     /// # Returns:
     /// A [`RedsumerResult`] with the result of the operation.
@@ -325,9 +327,9 @@ where
     /// Read new messages from a stream.
     ///
     /// # Arguments:
-    /// - **key**: A stream key, which must implement the `ToRedisArgs` trait.
-    /// - **group**: A consumers group, which must implement the `ToRedisArgs` trait.
-    /// - **consumer**: A consumer name, which must implement the `ToRedisArgs` trait.
+    /// - **key**: A stream key.
+    /// - **group**: A consumers group.
+    /// - **consumer**: A consumer name.
     /// - **count**: The number of messages to read.
     /// - **block**: The time to block waiting for new messages.
     ///
@@ -350,10 +352,10 @@ where
     /// Read pending messages from a stream.
     ///
     /// # Arguments:
-    /// - **key**: A stream key, which must implement the `ToRedisArgs` trait.
-    /// - **group**: A consumers group, which must implement the `ToRedisArgs` trait.
-    /// - **consumer**: A consumer name, which must implement the `ToRedisArgs` trait.
-    /// - **latest_pending_message_id**: The ID of the latest pending message, which must implement the `ToRedisArgs` trait.
+    /// - **key**: A stream key.
+    /// - **group**: A consumers group.
+    /// - **consumer**: A consumer name.
+    /// - **latest_pending_message_id**: The latest pending message ID.
     /// - **count**: The number of messages to read.
     ///
     /// # Returns:
@@ -376,11 +378,11 @@ where
     /// Claim pending messages from a stream.
     ///
     /// # Arguments:
-    /// - **key**: A stream key, which must implement the `ToRedisArgs` trait.
-    /// - **group**: A consumers group, which must implement the `ToRedisArgs` trait.
-    /// - **consumer**: A consumer name, which must implement the `ToRedisArgs` trait.
+    /// - **key**: A stream key.
+    /// - **group**: A consumers group.
+    /// - **consumer**: A consumer name.
     /// - **min_idle_time**: The minimum idle time in milliseconds.
-    /// - **next_id_to_claim**: The next ID to claim, which must implement the `ToRedisArgs` trait.
+    /// - **next_id_to_claim**: The next ID to claim.
     /// - **count**: The number of messages to claim.
     ///
     /// # Returns:
@@ -404,10 +406,10 @@ where
     /// Verify if a message is still in the consumer pending list.
     ///
     /// # Arguments:
-    /// - **key**: A stream key, which must implement the `ToRedisArgs` trait.
-    /// - **group**: A consumers group, which must implement the `ToRedisArgs` trait.
-    /// - **consumer**: A consumer name, which must implement the `ToRedisArgs` trait.
-    /// - **id**: The ID of the message to verify, which must implement the `ToRedisArgs` trait.
+    /// - **key**: A stream key.
+    /// - **group**: A consumers group.
+    /// - **consumer**: A consumer name.
+    /// - **id**: The message ID to verify.
     ///
     /// # Returns:
     /// A [`RedsumerResult`] with a boolean value. If the message is still in the consumer pending list, the function will return `true`. If the message is not in the consumer pending list, the function will return `false`. If an error occurs, the function will return an error result.
@@ -427,12 +429,12 @@ where
         CN: ToRedisArgs,
         ID: ToRedisArgs;
 
-    /// Acknowledge a message in a consumer group.
+    /// Ack a message in a consumer group.
     ///
     /// # Arguments:
-    /// - **key**: A stream key, which must implement the `ToRedisArgs` trait.
-    /// - **group**: A consumers group, which must implement the `ToRedisArgs` trait.
-    /// - **id**: The ID of the message to acknowledge, which must implement the `ToRedisArgs` trait.
+    /// - **key**: A stream key.
+    /// - **group**: A consumers group.
+    /// - **id**: The message ID to ack.
     ///
     /// # Returns:
     /// A [`RedsumerResult`] with a boolean value. If the message was successfully acknowledged, the function will return `true`. If the message was not acknowledged, the function will return `false`. If an error occurs, the function will return an error result.

--- a/redsumer-core/src/redsumer_core/streams/producer.rs
+++ b/redsumer-core/src/redsumer_core/streams/producer.rs
@@ -4,7 +4,9 @@ use tracing::{debug, error};
 #[allow(unused_imports)]
 use crate::redsumer_core::result::{RedsumerError, RedsumerResult};
 
-/// Produce a message to a Redis stream from a map. To set the ID of the message, this method use the value "*" to indicate that Redis should generate a new ID with the current timestamp.
+/// Produce a message to a stream from a map.
+/// 
+/// To set the ID of the message, this method use the value "*" to indicate that server should generate a new ID with the current timestamp.
 fn produce_from_map<C, K, M, ID>(c: &mut C, key: K, map: M) -> RedisResult<ID>
 where
     C: Commands,
@@ -24,7 +26,9 @@ where
     }
 }
 
-/// Produce a message to a Redis stream from a list of items. To set the ID of the message, this method use the value "*" to indicate that Redis should generate a new ID with the current timestamp.
+/// Produce a message to a stream from a list of items.
+/// 
+/// To set the ID of the message, this method use the value "*" to indicate that server should generate a new ID with the current timestamp.
 fn produce_from_items<C, K, F, V, ID>(c: &mut C, key: K, items: &[(F, V)]) -> RedisResult<ID>
 where
     C: Commands,
@@ -45,13 +49,13 @@ where
     }
 }
 
-/// A trait that bundles methods for producing messages in a Redis stream
+/// A trait that bundles methods for producing messages to a stream
 pub trait ProducerCommands {
-    /// Produce a message to a Redis stream from a map.
+    /// Produce a message to a stream from a map.
     ///
     /// # Arguments:
-    /// - **key**: The key of the Redis stream, which must implement the `ToRedisArgs` trait.
-    /// - **map**: A map with the message fields and values, which must implement the `ToRedisArgs` trait.
+    /// - **key**: The stream key.
+    /// - **map**: A map with the fields and values of the message.
     ///
     /// # Returns:
     /// A [`RedsumerResult`] with the message ID if the message was produced successfully. Otherwise, a [`RedsumerError`] is returned.
@@ -60,11 +64,11 @@ pub trait ProducerCommands {
         K: ToRedisArgs,
         M: ToRedisArgs;
 
-    /// Produce a message to a Redis stream from a list of items.
+    /// Produce a message to a stream from a list of items.
     ///
     /// # Arguments:
-    ///  - **key**: The key of the Redis stream, which must implement the `ToRedisArgs` trait.
-    /// - **items**: A list of tuples with the message fields and values, which must implement the `ToRedisArgs` trait.
+    ///  - **key**: The stream key.
+    /// - **items**: A list of tuples with the fields and values of the message.
     ///
     /// # Returns:
     /// A [`RedsumerResult`] with the message ID if the message was produced successfully. Otherwise, a [`RedsumerError`] is returned.

--- a/redsumer-core/src/redsumer_core/streams/producer.rs
+++ b/redsumer-core/src/redsumer_core/streams/producer.rs
@@ -5,7 +5,7 @@ use tracing::{debug, error};
 use crate::redsumer_core::result::{RedsumerError, RedsumerResult};
 
 /// Produce a message to a stream from a map.
-/// 
+///
 /// To set the ID of the message, this method use the value "*" to indicate that server should generate a new ID with the current timestamp.
 fn produce_from_map<C, K, M, ID>(c: &mut C, key: K, map: M) -> RedisResult<ID>
 where
@@ -27,7 +27,7 @@ where
 }
 
 /// Produce a message to a stream from a list of items.
-/// 
+///
 /// To set the ID of the message, this method use the value "*" to indicate that server should generate a new ID with the current timestamp.
 fn produce_from_items<C, K, F, V, ID>(c: &mut C, key: K, items: &[(F, V)]) -> RedisResult<ID>
 where


### PR DESCRIPTION
This pull request includes several changes to the `redsumer-core` package, focusing on documentation improvements, renaming for clarity, and updating descriptions to be more generic and less Redis-specific. The most important changes include updates to the `README.md`, `Cargo.toml`, and various source files to enhance clarity and consistency.

Documentation and Descriptions:

* [`redsumer-core/README.md`](diffhunk://#diff-507595a55f7c70c6b1e20ca8c9b7ee26cf4a672cfa9a799713b4b31fd97b6ec8R1-R17): Added a detailed description of the package, license information, and contributing guidelines.
* [`redsumer-core/CHANGELOG.md`](diffhunk://#diff-77d93a037d4357076d80ae3ad8c90b1cc19f3e839164c02596d69ecfd600086dR1-R12): Created a new changelog file to document notable changes in the package.
* [`redsumer-core/Cargo.toml`](diffhunk://#diff-658a5397eb83aa6d01ddb1eda8b03231e0a9868d03ed9709995aac0a6484c17eL3-R3): Updated the package description to "Core functionalities for redsumer written in Rust" to better reflect its purpose.

Code Documentation and Naming:

* [`redsumer-core/src/redsumer_core/client.rs`](diffhunk://#diff-9b8cae1a1ca947a0a3407e61602b3d8e45bb93923e8490fd71d61c67ba5c11f8L139-R139): Renamed `RedisClientBuilder` to `ClientBuilder` and updated comments to use "server" instead of "Redis" for a more generic description. [[1]](diffhunk://#diff-9b8cae1a1ca947a0a3407e61602b3d8e45bb93923e8490fd71d61c67ba5c11f8L139-R139) [[2]](diffhunk://#diff-9b8cae1a1ca947a0a3407e61602b3d8e45bb93923e8490fd71d61c67ba5c11f8L150-R150)
* [`redsumer-core/src/redsumer_core/connection.rs`](diffhunk://#diff-857bcf81a29e3132e0b4804316c4283c2a8a106489dd98f796c13d9af01c9a32R7-R29): Updated comments and error messages to use "server" instead of "Redis" for a more generic description. [[1]](diffhunk://#diff-857bcf81a29e3132e0b4804316c4283c2a8a106489dd98f796c13d9af01c9a32R7-R29) [[2]](diffhunk://#diff-857bcf81a29e3132e0b4804316c4283c2a8a106489dd98f796c13d9af01c9a32L75-R78)
* [`redsumer-core/src/redsumer_core/streams/consumer.rs`](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L56-R56): Updated comments to use "stream" and "server" instead of "Redis stream" and "Redis server" for a more generic description. [[1]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L56-R56) [[2]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9R85-R86) [[3]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L286-R296) [[4]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L303-R310) [[5]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L328-R332) [[6]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L353-R358) [[7]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L379-R385) [[8]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L407-R412) [[9]](diffhunk://#diff-0f57dc634a97e2f606eb67539d050b875062771e36f4744d71ee36017559adb9L430-R437)
* [`redsumer-core/src/redsumer_core/streams/producer.rs`](diffhunk://#diff-105cedd41c27272c33e9640263ef34cca987f2ba723c874ef874a87740d2c19aL7-R9): Updated comments to use "stream" instead of "Redis stream" for a more generic description. [[1]](diffhunk://#diff-105cedd41c27272c33e9640263ef34cca987f2ba723c874ef874a87740d2c19aL7-R9) [[2]](diffhunk://#diff-105cedd41c27272c33e9640263ef34cca987f2ba723c874ef874a87740d2c19aL27-R31) [[3]](diffhunk://#diff-105cedd41c27272c33e9640263ef34cca987f2ba723c874ef874a87740d2c19aL48-R58) [[4]](diffhunk://#diff-105cedd41c27272c33e9640263ef34cca987f2ba723c874ef874a87740d2c19aL63-R71)

These changes aim to improve the clarity and maintainability of the `redsumer-core` package by providing more accurate and generic descriptions, making the codebase easier to understand and contribute to.