### PR TITLE
Update runs-on parameter for all jobs in CI and update crate version to v05.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-    - "main"
+      - "main"
   pull_request:
     branches:
-    - "main"
+      - "main"
   schedule:
     - cron: "0 5 * * 0"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches:
+    - "main"
   pull_request:
-    branches: ["main"]
+    branches:
+    - "main"
   schedule:
     - cron: "0 5 * * 0"
 
@@ -15,7 +17,7 @@ env:
 
 jobs:
   Project-Config:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch Repository
         uses: actions/checkout@v4
@@ -47,7 +49,7 @@ jobs:
         run: taplo fmt --check --verbose --diff
 
   Docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: Project-Config
     steps:
       - name: Fetch Repository
@@ -63,7 +65,7 @@ jobs:
         run: cargo test --workspace --all-features --doc
 
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: Project-Config
     steps:
       - name: Fetch Repository
@@ -84,7 +86,7 @@ jobs:
         run: cargo build --workspace --all-features
 
   Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: Build
     steps:
       - name: Fetch Repository
@@ -99,7 +101,7 @@ jobs:
         run: cargo llvm-cov nextest --workspace --all-features --show-missing-lines --summary-only --fail-under-lines ${{ env.MIN_LINE_COVERAGE_TARGET }}
 
   Security:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: Build
     steps:
       - name: Fetch Repository

--- a/redsumer-rs/Cargo.toml
+++ b/redsumer-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redsumer"
 description = "Lightweight implementation of Redis Streams for Rust"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 license-file = "../LICENSE"
 readme = "../README.md"


### PR DESCRIPTION
This pull request includes updates to the CI configuration and a version bump for the `redsumer` package. The most important changes include modifying the branches configuration for GitHub Actions and updating the Ubuntu version used in the CI jobs.

Changes to CI configuration:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L5-R9): Modified the branches configuration for `push` and `pull_request` events to use a list format.
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L18-R20): Updated the `runs-on` parameter for all jobs to use `ubuntu-24.04` instead of `ubuntu-latest`. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L18-R20) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L50-R52) [[3]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L66-R68) [[4]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L87-R89) [[5]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L102-R104)

Version bump:

* [`redsumer-rs/Cargo.toml`](diffhunk://#diff-8263ffd4fca01ca77c83a85e9a0e49d3cc4f58aee24d2118d93f02e2fd1d456aL4-R4): Updated the version from `0.5.2` to `0.5.3`.